### PR TITLE
Lock initialization moved to _write_and_read

### DIFF
--- a/sartorius/util.py
+++ b/sartorius/util.py
@@ -33,7 +33,7 @@ class TcpClient():
         self.timeouts = 0
         self.max_timeouts = 10
         self.connection = None
-        self.lock = asyncio.Lock()
+        self.lock = None
 
     def __enter__(self):
         """Provide entrance to context manager."""
@@ -74,6 +74,9 @@ class TcpClient():
         As industrial devices are commonly unplugged, this has been expanded to
         handle recovering from disconnects.  A lock is used to queue multiple requests.
         """
+        if not self.lock:
+            # lock initialized here so the loop exists.
+            self.lock = asyncio.Lock()
         async with self.lock:  # lock releases on CancelledError
             await self._handle_connection()
             if self.open:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name="sartorius",
-    version="0.2.1",
+    version="0.2.2",
     description="Python driver for Sartorius and Minebea Intec scales.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Lock initialization moved from `__init__` to `_write_and_read` so it won't raise an exception due to non-existing event loop.