### PR TITLE
Use timeout for initial connect

### DIFF
--- a/sartorius/util.py
+++ b/sartorius/util.py
@@ -44,7 +44,7 @@ class TcpClient():
 
         Contrasting synchronous access, this will connect on initialization.
         """
-        await self._connect()
+        await self._handle_connection()
         return self
 
     def __exit__(self, *args):


### PR DESCRIPTION
Closes #10

Before:
```
a.ruddick@halcyon scripts % time sartorius 192.168.1.240
Traceback (most recent call last):
  File "/opt/homebrew/bin/sartorius", line 8, in <module>
    sys.exit(command_line())
  File "/opt/homebrew/lib/python3.9/site-packages/sartorius/__init__.py", line 32, in command_line
    asyncio.run(get())
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/opt/homebrew/lib/python3.9/site-packages/sartorius/__init__.py", line 25, in get
    async with Scale(args.address) as scale:
  File "/opt/homebrew/lib/python3.9/site-packages/sartorius/util.py", line 47, in __aenter__
    await self._connect()
  File "/opt/homebrew/lib/python3.9/site-packages/sartorius/util.py", line 67, in _connect
    reader, writer = await asyncio.open_connection(self.ip, self.port)
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/streams.py", line 52, in open_connection
    transport, _ = await loop.create_connection(
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 1065, in create_connection
    raise exceptions[0]
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 1050, in create_connection
    sock = await self._connect_sock(
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 961, in _connect_sock
    await self.sock_connect(sock, address)
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/selector_events.py", line 500, in sock_connect
    return await fut
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/selector_events.py", line 535, in _sock_connect_cb
    raise OSError(err, f'Connect call failed {address}')
TimeoutError: [Errno 60] Connect call failed ('192.168.1.240', 49155)
```
`sartorius 192.168.1.240 0.06s user 0.02s system 0% cpu 1:16.10 total`

After:
```
a.ruddick@halcyon sartorius % time sartorius 192.168.1.240
Connecting to 192.168.1.240 timed out.
{
    "on": false
}
```
