### PR TITLE
Handle different types of bad replies

### DIFF
--- a/sartorius/driver.py
+++ b/sartorius/driver.py
@@ -33,11 +33,19 @@ class Scale(TcpClient):
 
     async def get_info(self):
         """Get scale model, serial, and software version numbers."""
-        return {
-            'model': (await self._write_and_read('\x1bx1_') or '').strip(),
-            'serial': (await self._write_and_read('\x1bx2_') or '').strip(),
-            'software': (await self._write_and_read('\x1bx3_') or '').strip(),
+        model = (await self._write_and_read('\x1bx1_')).strip()
+        serial = (await self._write_and_read('\x1bx2_')).strip()
+        software = (await self._write_and_read('\x1bx3_')).strip()
+        response = {
+            'model': model,
+            'serial': serial,
+            'software': software,
         }
+        for item in response.values():
+            if (' + ' in item or ' kg' in item):
+                logger.error(f"Received malformed data: {response}")
+                return {}
+        return response
 
     async def zero(self):
         """Tare and zero the scale."""

--- a/sartorius/util.py
+++ b/sartorius/util.py
@@ -35,10 +35,6 @@ class TcpClient():
         self.connection = None
         self.lock = None
 
-    def __enter__(self):
-        """Provide entrance to context manager."""
-        return self
-
     async def __aenter__(self):
         """Provide async entrance to context manager.
 

--- a/sartorius/util.py
+++ b/sartorius/util.py
@@ -80,7 +80,11 @@ class TcpClient():
         async with self.lock:  # lock releases on CancelledError
             await self._handle_connection()
             if self.open:
-                response = await self._handle_communication(command)
+                try:
+                    response = await self._handle_communication(command)
+                except asyncio.exceptions.IncompleteReadError:
+                    logger.error('IncompleteReadError.  Are there multiple connections?')
+                    return {}
             else:
                 response = None
         return response


### PR DESCRIPTION
Closes #4 

Before (two connections fighting):
```
 File "/Users/a.ruddick/Documents/github/sartorius/sartorius/__init__.py", line 30, in get
    d = await scale.get()
  File "/Users/a.ruddick/Documents/github/sartorius/sartorius/driver.py", line 31, in get
    response = await self._write_and_read('\x1bP')
  File "/Users/a.ruddick/Documents/github/sartorius/sartorius/util.py", line 83, in _write_and_read
    response = await self._handle_communication(command)
  File "/Users/a.ruddick/Documents/github/sartorius/sartorius/util.py", line 104, in _handle_communication
    line = await asyncio.wait_for(future, timeout=0.5)
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/tasks.py", line 445, in wait_for
    return fut.result()
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/streams.py", line 614, in readuntil
    raise exceptions.IncompleteReadError(chunk, None)
asyncio.exceptions.IncompleteReadError: 0 bytes read on a total of undefined expected bytes
```

After (two connections fighting):
```
a.ruddick@halcyon sartorius % time sartorius 192.168.1.240
IncompleteReadError.  Are there multiple connections?
Received malformed data: {}
{
    "on": false
}
```

Before (reply out of order):
```
a.ruddick@halcyon sartorius % time sartorius 192.168.1.240
{
    "mass": 0.0,
    "units": "kg",
    "stable": true,
    "info": {
        "model": "N     +   0.0000 kg",
        "serial": "SIWADCP-1-",
        "software": "38666696"
    }
}
sartorius 192.168.1.240  0.08s user 0.02s system 31% cpu 0.321 total
```

After (reply out of order):
```
Received malformed data: {'model': 'N     +   1.3125 kg', 'serial': 'SIWADCP-1-', 'software': '38666696'}
{
    "mass": 1.3125,
    "units": "kg",
    "stable": true,
    "info": {}
}
```