### PR TITLE
Split protocol/transport and add serial support

### DIFF
--- a/sartorius/__init__.py
+++ b/sartorius/__init__.py
@@ -16,9 +16,7 @@ def command_line(args: Any = None) -> None:
     import json
 
     parser = argparse.ArgumentParser(description="Read scale status.")
-    parser.add_argument('address', help="The IP address of the scale.")
-    parser.add_argument('-p', '--port', help="The port of the scale (default 49155)",
-                        type=int, default=49155)
+    parser.add_argument('address', help="The serial or IP address of the scale.")
     parser.add_argument('-n', '--no-info', action='store_true', help="Exclude "
                         "scale information. Reduces communication overhead.")
     parser.add_argument('-z', '--zero', action='store_true', help="Tares and "
@@ -26,7 +24,7 @@ def command_line(args: Any = None) -> None:
     args = parser.parse_args(args)
 
     async def get() -> None:
-        async with Scale(args.address, args.port) as scale:
+        async with Scale(address=args.address) as scale:
             if args.zero:
                 await scale.zero()
             d = await scale.get()

--- a/sartorius/driver.py
+++ b/sartorius/driver.py
@@ -5,39 +5,60 @@ Distributed under the GNU General Public License v2
 Copyright (C) 2019 NuMat Technologies
 """
 import logging
+from typing import Any
 
 from sartorius.util import TcpClient
 
 logger = logging.getLogger('sartorius')
 
 
-class Scale(TcpClient):
+class Scale:
     """Driver for Sartorius and Minebea Intec ethernet scales.
 
     This implements a version of the Scale Manufacturers Association
     standardized communications protocol.
     """
 
-    def __init__(self, ip: str, port: int = 49155) -> None:
-        """Set up connection parameters, IP address and port."""
+    def __init__(self, ip: str = None, port: int = 49155,
+                 address: str = None, **kwargs) -> None:
+        """Set up connection parameters, IP address and port.
+
+        Accepts either an address string (TCP or serial), or combination
+        of port & ip (TCP, backwards compatible)
+        """
+        if ip:
+            if ":" in ip:
+                port = int(ip.split(":")[1])
+                ip = ip.split(':')[0]
+                address = ip
+            address = f'{ip}:{port}'
         self.units: str = ""
-        if ":" in ip:
-            port = int(ip.split(":")[1])
-            ip = ip.split(':')[0]
-        super().__init__(ip, port)
+        if address.startswith('/dev') or address.startswith('COM'):  # serial
+            raise NotImplementedError
+            # self.hw: Client = SerialClient(address=address, **kwargs)
+        else:
+            self.hw = TcpClient(address=address, **kwargs)
+
+    async def __aenter__(self, *args: Any) -> Any:
+        """Provide async enter to context manager."""
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        """Provide async exit to context manager."""
+        return
 
     async def get(self) -> dict:
         """Get scale reading."""
-        response = await self._write_and_read('\x1bP')
+        response = await self.hw._write_and_read('\x1bP')
         if not response:
             raise OSError("Unable to get reading from scale.")
         return self._parse(response)
 
     async def get_info(self) -> dict:
         """Get scale model, serial, and software version numbers."""
-        model = await self._write_and_read('\x1bx1_')
-        serial = await self._write_and_read('\x1bx2_')
-        software = await self._write_and_read('\x1bx3_')
+        model = await self.hw._write_and_read('\x1bx1_')
+        serial = await self.hw._write_and_read('\x1bx2_')
+        software = await self.hw._write_and_read('\x1bx3_')
         if not (model and serial and software):
             raise OSError("Unable to get information from scale.")
         response = {
@@ -53,7 +74,7 @@ class Scale(TcpClient):
 
     async def zero(self) -> None:
         """Tare and zero the scale."""
-        await self._write_and_read('\x1bT')
+        await self.hw._write_and_read('\x1bT')
 
     def _parse(self, response: str) -> dict:
         """Parse a scale response.

--- a/sartorius/driver.py
+++ b/sartorius/driver.py
@@ -19,8 +19,8 @@ class Scale:
     standardized communications protocol.
     """
 
-    def __init__(self, ip: str = '', port: int = 49155,
-                 address: str = '', **kwargs: Any) -> None:
+    def __init__(self, address: str = '', ip: str = '', port: int = 49155,
+                 **kwargs: Any) -> None:
         """Set up connection parameters, IP address and port.
 
         Accepts either an address string (TCP or serial), or combination
@@ -36,6 +36,8 @@ class Scale:
         if address.startswith('/dev') or address.startswith('COM'):  # serial
             self.hw: Client = SerialClient(address=address, **kwargs)
         else:
+            if ':' not in address:
+                address = f'{address}:{port}'
             self.hw = TcpClient(address=address, **kwargs)
 
     async def __aenter__(self, *args: Any) -> 'Scale':

--- a/sartorius/driver.py
+++ b/sartorius/driver.py
@@ -7,7 +7,7 @@ Copyright (C) 2019 NuMat Technologies
 import logging
 from typing import Any
 
-from sartorius.util import TcpClient
+from sartorius.util import Client, SerialClient, TcpClient
 
 logger = logging.getLogger('sartorius')
 
@@ -34,8 +34,7 @@ class Scale:
             address = f'{ip}:{port}'
         self.units: str = ""
         if address.startswith('/dev') or address.startswith('COM'):  # serial
-            raise NotImplementedError
-            # self.hw: Client = SerialClient(address=address, **kwargs)
+            self.hw: Client = SerialClient(address=address, **kwargs)
         else:
             self.hw = TcpClient(address=address, **kwargs)
 

--- a/sartorius/driver.py
+++ b/sartorius/driver.py
@@ -19,14 +19,14 @@ class Scale:
     standardized communications protocol.
     """
 
-    def __init__(self, ip: str = None, port: int = 49155,
-                 address: str = None, **kwargs) -> None:
+    def __init__(self, ip: str = '', port: int = 49155,
+                 address: str = '', **kwargs: Any) -> None:
         """Set up connection parameters, IP address and port.
 
         Accepts either an address string (TCP or serial), or combination
         of port & ip (TCP, backwards compatible)
         """
-        if ip:
+        if ip != '':
             if ":" in ip:
                 port = int(ip.split(":")[1])
                 ip = ip.split(':')[0]

--- a/sartorius/driver.py
+++ b/sartorius/driver.py
@@ -39,7 +39,7 @@ class Scale:
         else:
             self.hw = TcpClient(address=address, **kwargs)
 
-    async def __aenter__(self, *args: Any) -> Any:
+    async def __aenter__(self, *args: Any) -> 'Scale':
         """Provide async enter to context manager."""
         return self
 

--- a/sartorius/mock.py
+++ b/sartorius/mock.py
@@ -5,8 +5,18 @@ from random import choice, random
 from typing import Any
 from unittest.mock import MagicMock
 
+from .driver import Scale as RealScale
 
-class Scale(MagicMock):
+
+class AsyncClientMock(MagicMock):
+    """Magic mock that works with async methods."""
+
+    async def __call__(self, *args, **kwargs):  # type: ignore [no-untyped-def]
+        """Convert regular mocks into into an async coroutine."""
+        return super().__call__(*args, **kwargs)
+
+
+class Scale(RealScale):
     """Mocks the Scale driver for offline testing."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -15,14 +25,6 @@ class Scale(MagicMock):
         self.info = {"model": "SIWADCP-1-",
                      "serial": "37454321",
                      "software": "00-37-09"}
-
-    async def __aenter__(self, *args: Any) -> Any:
-        """Set up connection."""
-        return self
-
-    async def __aexit__(self, *args: Any) -> None:
-        """Close connection."""
-        pass
 
     async def get(self) -> dict:
         """Get scale reading."""

--- a/sartorius/util.py
+++ b/sartorius/util.py
@@ -6,12 +6,13 @@ Copyright (C) 2019 NuMat Technologies
 
 import asyncio
 import logging
+from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger('sartorius')
 
 
-class Client:
+class Client(ABC):
     """Base class for a generic reconnecting client."""
 
     def __init__(self) -> None:
@@ -58,13 +59,15 @@ class Client:
                 response = None
         return response
 
+    @abstractmethod
     async def _handle_connection(self) -> None:
         """Automatically maintain the connection."""
-        raise NotImplementedError
+        ...
 
+    @abstractmethod
     async def _handle_communication(self, command: str) -> Optional[str]:
         """Manage communication, including timeouts and logging."""
-        raise NotImplementedError
+        ...
 
 
 class TcpClient(Client):

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,6 @@ addopts = --cov=sartorius
 [mypy]
 check_untyped_defs = True
 disallow_untyped_defs = True
-exclude = tests
+
+[mypy-tests.*]
+allow_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,16 @@ setup(
     author_email="pat@numat-tech.com",
     packages=['sartorius'],
     package_data={'sartorius': ['py.typed']},
+    install_requires=['pyserial'],
     extras_require={
+
         'test': [
             'mypy==1.3.0',
             'pytest>=6,<8',
             'pytest-cov>=4,<5',
             'pytest-asyncio==0.*',
-            'ruff==0.0.269'
+            'ruff==0.0.269',
+            'types-pyserial',
         ]
     },
     entry_points={

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -10,7 +10,7 @@ from sartorius.mock import Scale
 @pytest.fixture()
 def scale_driver():
     """Confirm the scale correctly initializes."""
-    return Scale('fakeip')
+    return Scale('fakeip:49155')
 
 
 @pytest.fixture()
@@ -24,7 +24,7 @@ def expected_response():
 @mock.patch('sartorius.Scale', Scale)
 def test_driver_cli(capsys):
     """Confirm the commandline interface works."""
-    command_line(['fakeip'])
+    command_line(['fakeip:49155'])
     captured = capsys.readouterr()
     assert '"stable": true' in captured.out
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -29,7 +29,12 @@ def test_driver_cli(capsys):
     assert '"stable": true' in captured.out
 
 
-def test_parse(scale_driver):
+@pytest.mark.parametrize(('response', 'expected'),
+                         #  KKKKKK+*AAAAAAAA*EEECRLF    mass   units  stable
+                         [('N     +   0.1234 g  \r\n', (0.1234, 'g', True)),
+                          ('N     +   9.9999 kg \r\n', (9.9999, 'kg', True)),
+                          ('N     +   5.4321    \r\n', (5.4321, '', False))])
+def test_parse(scale_driver, response, expected):
     """Test the response parsing code.
 
     Scale weight is returned according to the SMA communication standard:
@@ -40,13 +45,11 @@ def test_parse(scale_driver):
     A: Digit or letter
     E: unit symbol
     """
-    #          'KKKKKK+*AAAAAAAA*EEECRLF'
-    response = 'N     +   0.1234 g  \r\n'
     result = scale_driver._parse(response)
 
-    assert result['mass'] == 0.1234
-    assert result['units'] == 'g'
-    assert result['stable'] is True
+    assert result['mass'] == expected[0]
+    assert result['units'] == expected[1]
+    assert result['stable'] == expected[2]
 
 
 async def test_get_response(scale_driver, expected_response):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -29,6 +29,26 @@ def test_driver_cli(capsys):
     assert '"stable": true' in captured.out
 
 
+def test_parse(scale_driver):
+    """Test the response parsing code.
+
+    Scale weight is returned according to the SMA communication standard:
+    K K K K K K + * A A A A A A A A * E E E CR LF
+    K: ID code character
+    +: plus or minus
+    *: space
+    A: Digit or letter
+    E: unit symbol
+    """
+    #          'KKKKKK+*AAAAAAAA*EEECRLF'
+    response = 'N     +   0.1234 g  \r\n'
+    result = scale_driver._parse(response)
+
+    assert result['mass'] == 0.1234
+    assert result['units'] == 'g'
+    assert result['stable'] is True
+
+
 async def test_get_response(scale_driver, expected_response):
     """Confirm that the driver returns correct values on get_info() calls."""
     assert expected_response == await scale_driver.get_info()

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -6,11 +6,13 @@ import pytest
 from sartorius import command_line
 from sartorius.mock import Scale
 
+ADDRESS = 'fakeip:49155'
+
 
 @pytest.fixture()
 def scale_driver():
     """Confirm the scale correctly initializes."""
-    return Scale('fakeip:49155')
+    return Scale(ADDRESS)
 
 
 @pytest.fixture()
@@ -24,7 +26,7 @@ def expected_response():
 @mock.patch('sartorius.Scale', Scale)
 def test_driver_cli(capsys):
     """Confirm the commandline interface works."""
-    command_line(['fakeip:49155'])
+    command_line([ADDRESS])
     captured = capsys.readouterr()
     assert '"stable": true' in captured.out
 
@@ -68,7 +70,7 @@ async def test_readme_example(expected_response):
     """Confirm the readme example using an async context manager works."""
 
     async def get():
-        async with Scale('scale-ip.local') as scale:
+        async with Scale(ADDRESS) as scale:
             await scale.zero()             # Zero and tare the scale
             response = await scale.get()       # Get mass, units, stability
             assert response['stable'] is True

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -52,6 +52,13 @@ def test_parse(scale_driver, response, expected):
     assert result['stable'] == expected[2]
 
 
+def test_parse_errors(scale_driver):
+    """Test error handling of response parsing code."""
+    response = 'G     +   0.1234 g  \r\n'
+    with pytest.raises(ValueError, match='This driver only supports net weight.'):
+        scale_driver._parse(response)
+
+
 async def test_get_response(scale_driver, expected_response):
     """Confirm that the driver returns correct values on get_info() calls."""
     assert expected_response == await scale_driver.get_info()


### PR DESCRIPTION
The current driver only support TCP connections, and the transport/interface are tightly coupled.  This decouples them, allowing for swapping different transport layers.  Then it adds a serial transport.  (Closes https://github.com/numat/sartorius/issues/22)

The CLI invocation and arguments support two ways of passing IP:port (to keep support for the existing ION-X usage)

For bonus points:
 - More unit tests!
 - Push the mock lower down the stack to test more code!
